### PR TITLE
Execute the Party service under a dedicated non-root user account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,7 @@ FROM alpine:latest
 RUN apk update && apk upgrade
 COPY build/linux-amd64/bin/partysvc /usr/local/bin/
 EXPOSE 8081
+RUN addgroup -g 988 partysvc && \
+    adduser -u 988 -S partysvc -G partysvc
+USER partysvc
 ENTRYPOINT ["/usr/local/bin/partysvc"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ WORKDIR /app
 RUN go build -o main .
 
 FROM alpine:latest
-COPY --from=build /app/main .
-EXPOSE 8081
 RUN addgroup -g 988 partysvc && \
     adduser -u 988 -S partysvc -G partysvc
 USER partysvc
-ENTRYPOINT ["/usr/local/bin/partysvc"]
-
-CMD ["./main"]
+COPY --from=build /app/main .
+EXPOSE 8081
+ENTRYPOINT ["./main"]


### PR DESCRIPTION
# Motivation and Context
The principle of using least privilege should be followed when executing code within containers. Specifically, not running as root.

# What has changed
The Dockerfile has been changed:

* Create a dedicated non-root user account for executing the Go code

# How to test?
I tested this change by creating a differently tagged Docker image and deploying to my Kubernetes cluster. I verified that:

* The pod started successfully
* The Kubernetes readiness and liveness probes succeeded
* There were no errors in the container logs
* `exec`-ing into the container showed the Go process running as the expected non-root user account